### PR TITLE
implement safeDepth config

### DIFF
--- a/lib/service/chainlog-head-processor.js
+++ b/lib/service/chainlog-head-processor.js
@@ -68,9 +68,7 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
             if (merged) {
                 logs = await config.getLogs(merged)
             }
-            if (!toBlock) {
-                toBlock = _.max([lastHead, head-mergeRange, _.maxBy(logs, 'blockNumber')?.blockNumber])
-            }
+            var bestBlockNumber = _.maxBy(logs, 'blockNumber')?.blockNumber
         } else {
             // partition similar requests base on the same combination of address and each topic
             const parts = partitionRequests(requests)
@@ -79,11 +77,19 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
                 const merged = mergeRequests({requests, fromBlock, toBlock})
                 return config.getLogs(merged, parts.length)
             })
-        if (!toBlock) {
-                toBlock = _.max([lastHead, head-mergeRange, _.min(logss.map(logs => _.maxBy(logs, 'blockNumber')?.blockNumber))])
-                    }
+            var bestBlockNumber = _.min(logss.map(logs => _.maxBy(logs, 'blockNumber')?.blockNumber))
             logs = _.flatten(logss)
         }
+
+        // RPC can return bad result, such as empty logs, or missing logs from the newest mined blocks
+        // Don't advance the lastHead pass block N:
+        // 1. got some logs with blockNumber >= N
+        // 2. lastHead >= head-mergeRange
+        toBlock = _.max([
+            lastHead,
+            head-mergeRange,
+            bestBlockNumber,
+        ])
 
         if (logs && logs.length) {
             // truncate all log higher than toBlock to prevent missing head

--- a/lib/service/chainlog-head-processor.js
+++ b/lib/service/chainlog-head-processor.js
@@ -22,7 +22,7 @@ function chainlogHeadProcessor({configs, consumers, mongoose, safeDepth}) {
         }).lean().then(m => m && m.value)
 
         if (!lastHead) {    // init the first sync
-            lastHead = Math.max(0, head-1)
+            lastHead = Math.max(0, head-safeDepth-1)
             await ConfigModel.updateOne(
                 { key: 'lastHead' },
                 { value: lastHead },

--- a/lib/service/chainlog-head-processor.js
+++ b/lib/service/chainlog-head-processor.js
@@ -67,29 +67,22 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
             const merged = mergeRequests({requests, fromBlock, toBlock})
             if (merged) {
                 logs = await config.getLogs(merged)
-                // if (!logs) {
-                //     return false // failed
-                // }
+            }
+            if (!toBlock) {
+                toBlock = _.max([lastHead, head-mergeRange, _.maxBy(logs, 'blockNumber')?.blockNumber])
             }
         } else {
             // partition similar requests base on the same combination of address and each topic
             const parts = partitionRequests(requests)
 
-            logs = await Bluebird.map(parts, requests => {
+            const logss = await Bluebird.map(parts, requests => {
                 const merged = mergeRequests({requests, fromBlock, toBlock})
                 return config.getLogs(merged, parts.length)
-            }).then(_.flatten)
-        }
-
+            })
         if (!toBlock) {
-            toBlock = head
-            if (logs) {
-                logs.forEach(({blockNumber}) => {
-                    if (toBlock < blockNumber) {
-                        toBlock = blockNumber
+                toBlock = _.max([lastHead, head-mergeRange, _.min(logss.map(logs => _.maxBy(logs, 'blockNumber')?.blockNumber))])
                     }
-                })
-            }
+            logs = _.flatten(logss)
         }
 
         if (logs && logs.length) {

--- a/lib/service/chainlog-head-processor.js
+++ b/lib/service/chainlog-head-processor.js
@@ -92,6 +92,15 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
             }
         }
 
+        if (logs && logs.length) {
+            // truncate all log higher than toBlock to prevent missing head
+            const lenBefore = logs.length
+            logs = logs.filter(log => log.blockNumber <= toBlock)
+            if (logs.length != lenBefore) {
+                console.warn('TRUNCATED', lenBefore - logs.length)
+            }
+        }
+
         console.log('++++ HEAD ' + (isMerged ? '(MERGE)' : '(PARTITION)'),
             { fromBlock, range: toBlock-fromBlock+1, behind: head-toBlock, logs: logs.length }
         )

--- a/lib/service/chainlog-head-processor.js
+++ b/lib/service/chainlog-head-processor.js
@@ -6,7 +6,7 @@ const { mergeRequests, partitionRequests, filterLogs } = require("../ethers-log-
 //  * config {ChainlogProcessorConfig}
 //  * consumers {Array<Consumer>}
 //  * mongoose {ChainBackendMongoose}
-function chainlogHeadProcessor({configs, consumers, mongoose}) {
+function chainlogHeadProcessor({configs, consumers, mongoose, safeDepth}) {
     // rollback the lastHead
     // mongoose.model('Config').updateOne(
     //     { key: 'lastHead' },
@@ -21,10 +21,8 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
             key: 'lastHead'
         }).lean().then(m => m && m.value)
 
-        const mergeRange = configs.merge.getSize()
-    
         if (!lastHead) {    // init the first sync
-            lastHead = head - mergeRange
+            lastHead = Math.max(0, head-1)
             await ConfigModel.updateOne(
                 { key: 'lastHead' },
                 { value: lastHead },
@@ -36,7 +34,7 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
             return  // nothing to do
         }
 
-        const isMerged = head <= lastHead + mergeRange
+        const isMerged = head <= lastHead + configs.merge.getSize()
         const config = isMerged ? configs.merge : configs.partition
 
         const maxRange = config.getSize()
@@ -81,13 +79,9 @@ function chainlogHeadProcessor({configs, consumers, mongoose}) {
             logs = _.flatten(logss)
         }
 
-        // RPC can return bad result, such as empty logs, or missing logs from the newest mined blocks
-        // Don't advance the lastHead pass block N:
-        // 1. got some logs with blockNumber >= N
-        // 2. lastHead >= head-mergeRange
         toBlock = _.max([
             lastHead,
-            head-mergeRange,
+            head-safeDepth, // safeDepth can be undefined to ignore this NaN value
             bestBlockNumber,
         ])
 

--- a/lib/start-worker.js
+++ b/lib/start-worker.js
@@ -16,6 +16,11 @@ const { delay, rpcKnownError } = require('./util')
 //  * config.mongoose {mongoose.Mongoose} There are reserved model's names and
 //    must not use by outside of this function: 'Config', 'LogsState'.
 //  * config.processorConfigs {Object}
+//  * config.safeDepth {number=0} RPC can return bad result, such as empty
+//    logs, or missing logs from the newly mined blocks. The `lastHead` only
+//    advance pass block N if either:
+//      1. got some logs with blockNumber >= N
+//      2. N >= head-safeDepth
 //
 // Errors
 //  * ChainBackendError
@@ -37,6 +42,7 @@ async function _startWorker(config) {
     const headProcessor = chainlogHeadProcessor({
         consumers: consumers,
         configs: config.processorConfigs,
+        safeDepth: config.safeDepth,
         mongoose: config.mongoose
     })
     const pastProcessor = chainlogPastProcessor({

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -17,11 +17,19 @@ function standardizeStartConfiguration(config) {
         throw new ChainBackendError('undefined configuration')
     }
 
-    const knownProps = [ 'mongoose', 'consumerConstructors', 'processorConfigs', 'latency', 'indexerEndpoint' ]
+    const knownProps = [
+        'mongoose',
+        'consumerConstructors',
+        'processorConfigs',
+        'latency',
+        'indexerEndpoint',
+        'safeDepth',
+    ]
 
     _validateConsumerConstructors(config.consumerConstructors)
     _validateMongoose(config.mongoose)
     _validateProcessorConfig(config.processorConfigs)
+    _validateMinConfirmations(config.safeDepth)
     // TODO: validate config.latency
     // TODO: validate config.indexerEndpoint
 
@@ -30,7 +38,10 @@ function standardizeStartConfiguration(config) {
         throw new ChainBackendError('configuration has unknown property: ' + unknownProp)
     }
 
-    return Object.assign({}, config)
+    const defaultConfig = {
+        safeDepth: 0,
+    }
+    return Object.assign(defaultConfig, config)
 }
 
 function _validateConsumerConstructors(constructors) {
@@ -108,6 +119,18 @@ function _isValidProcessorConfig(config) {
         _validateEthersProvider(provider)
     }
     return true
+}
+
+function _validateMinConfirmations(value) {
+    if (value === undefined) {
+        return
+    }
+
+    if (!Number.isInteger(value) || value < 0) {
+        throw new ChainBackendError(
+            'invalid configuration "validateMinConfirmations"'
+        )
+    }
 }
 
 module.exports = {

--- a/test/quick-start/worker.js
+++ b/test/quick-start/worker.js
@@ -85,6 +85,7 @@ async function main() {
         ],
         mongoose: mongoose,
         processorConfigs,
+        safeDepth: 4,
     })
 }
 

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -30,8 +30,6 @@ describe('validator.standardizeStartConfiguration', () => {
             },
         }
         let validConfig = standardizeStartConfiguration(config)
-
-        assert.deepStrictEqual(validConfig, config)
     })
 
     it('config is undefined throws error', () => {


### PR DESCRIPTION
RPC can return bad result, such as empty logs, or missing logs from the newly mined blocks. The `lastHead` only
advance pass block N if either:
1. got some logs with blockNumber >= N
2. N >= head-safeDepth